### PR TITLE
fix: number below synced

### DIFF
--- a/src/components/DayEditor.tsx
+++ b/src/components/DayEditor.tsx
@@ -109,7 +109,7 @@ export const DayEditor = ({ date, onClose }: DayEditorProps) => {
           <div className="pt-4 border-t border-border">
             <div className="flex items-center justify-between">
               <span className="text-sm text-muted-foreground">Completed</span>
-              <span className="text-lg font-medium text-foreground">{totalScore}/3</span>
+              <span className="text-lg font-medium text-foreground">{totalScore}/{HABITS.length}</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
**Explanation**:
We're now using the length of the HABITS to display at the bottom of the tile to add log

<img width="446" height="407" alt="Screenshot 2026-01-11 at 16 41 22" src="https://github.com/user-attachments/assets/dc03e96b-766c-440a-b1aa-15f7f0c915d9" />

**Risks**:
When introducing levels we need to filter by levels