### PR TITLE
front: removing the ring on the today square

### DIFF
--- a/src/components/ContributionGrid.tsx
+++ b/src/components/ContributionGrid.tsx
@@ -153,8 +153,7 @@ export const ContributionGrid = ({
                         w-[11px] h-[11px] rounded-sm transition-all
                         ${isInYear && !future ? getContributionClass(level) : "bg-transparent"}
                         cursor-default
-                        ${isSelected ? "ring-2 ring-foreground" : ""}
-                        ${isToday(day) ? "ring-1 ring-foreground/50" : ""}
+                        border-none outline-none ring-0
                       `}
                       title={isInYear ? format(day, "MMM d, yyyy") : ""}
                     />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **UI tweak: contribution grid cell styling**
> 
> - In `ContributionGrid.tsx`, removed conditional ring classes for `isSelected` and `isToday` states on day buttons.
> - Added `border-none`, `outline-none`, and `ring-0` to ensure no focus/selection ring or border appears on cells.
> - Grid cells remain disabled and use existing `getContributionClass` for coloring when applicable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd1baafafb6ce33109e9a9541550896069d9410d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->